### PR TITLE
Add option to use the projects local jsfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,15 @@ git clone https://github.com/ionutvmi/sublime-jsfmt jsfmt
         }
     },
     "alert-errors": true,
+
     // path to nodejs
     "node-path": "node",
+
     // if true it will format the whole file even if you have a selection active
-    "ignore-selection": false
+    "ignore-selection": false,
+
+    // if true it will use the projects local jsfmt/plugins
+    "use-local-jsfmt": true
 }
 
 ```

--- a/jsfmt-sublime.py
+++ b/jsfmt-sublime.py
@@ -56,6 +56,8 @@ class FormatJavascriptCommand(sublime_plugin.TextCommand):
             # grab the cwd
             if self.view.file_name():
                 cdir = dirname(self.view.file_name())
+                if settings.get('use-local-jsfmt', True):
+                    return node_bridge(data, BIN_PATH, cdir, [opt, scope, optJSON, cdir])
             else:
                 cdir = "/"
 

--- a/jsfmt.js
+++ b/jsfmt.js
@@ -1,11 +1,13 @@
 'use strict';
 
 var stdin = require('get-stdin');
-var jsfmt = require('jsfmt');
 var extend = require('extend');
+var path = require('path');
+var fs = require('fs');
 
 stdin(function(data) {
     var scope = process.argv[3];
+    var jsfmt = getJsfmt(process.argv[5]);
     var conf = jsfmt.getConfig();
     var optsJSON = extend({}, conf, JSON.parse(process.argv[4]));
     var opts = conf;
@@ -32,3 +34,19 @@ stdin(function(data) {
     }
 });
 
+function getJsfmt(localJsfmt) {
+    var jsfmt;
+    var loader = path.join(localJsfmt, '__sublime-load-jsfmt.js');
+    if (localJsfmt) {
+        try {
+            fs.writeFileSync(loader, "module.exports = require('jsfmt');");
+            jsfmt = require(loader);
+            fs.unlinkSync(loader);
+            return jsfmt;
+        } catch ( e ) {
+            throw e;
+            fs.unlinkSync(loader);
+        }
+    }
+    return require('jsfmt');
+}

--- a/jsfmt.sublime-settings
+++ b/jsfmt.sublime-settings
@@ -29,5 +29,6 @@
     },
     "node-path": "node",
     "alert-errors": true,
-    "ignore-selection": false
+    "ignore-selection": false,
+    "use-local-jsfmt": true
 }


### PR DESCRIPTION
Currently it writes a file into the directory where the file is saved to require('jsfmt'); There might be a better option to load jsfmt but I did not know how to do it without overwriting internal node apis.
